### PR TITLE
fix: skip assets with same owner id as currently authed user

### DIFF
--- a/ultima_scraper_collection/managers/datascraper_manager/datascrapers/onlyfans.py
+++ b/ultima_scraper_collection/managers/datascraper_manager/datascrapers/onlyfans.py
@@ -69,6 +69,8 @@ class OnlyFansDataScraper(StreamlinedDatascraper):
         await content_metadata.resolve_extractor(ApiExtractor(content_result))
         for asset in content_metadata.medias:
             if asset.urls:
+                if asset.__content_metadata__.__soft__.get_author().id == authed.id:
+                    continue
                 reformat_manager = ReformatManager(authed, self.filesystem_manager)
                 reformat_item = reformat_manager.prepare_reformat(asset)
                 if reformat_item.api_type == "Messages":


### PR DESCRIPTION
This addresses #1 

Also the following duplicated issues across other repos:
[#11](https://github.com/UltimaHoarder/UltimaScraperAPI/issues/11)
[#2099](https://github.com/UltimaHoarder/UltimaScraper/issues/2099)
[#1004](https://github.com/DIGITALCRIMINAL/ArchivedUltimaScraper/issues/1004)
[#1010](https://github.com/DIGITALCRIMINAL/ArchivedUltimaScraper/issues/1010)
[#1016](https://github.com/DIGITALCRIMINAL/ArchivedUltimaScraper/issues/1016)

